### PR TITLE
Do not fail the delete if providerConfig is not found

### DIFF
--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -22,12 +22,18 @@ import (
 
 	"github.com/23technologies/gardener-extension-provider-hcloud/pkg/controller/infrastructure/ensurer"
 	"github.com/23technologies/gardener-extension-provider-hcloud/pkg/hcloud/apis"
+	"github.com/23technologies/gardener-extension-provider-hcloud/pkg/hcloud/apis/transcoder"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
 func (a *actuator) delete(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
 	actuatorConfig, err := a.getActuatorConfig(ctx, infra, cluster)
+	// the shoot never reached the state of having a ProviderConfig assigned
+	// we can assume nothing was setup
+	if _, ok := err.(*transcoder.MissingProviderConfig); ok {
+		return a.updateProviderStatus(ctx, infra, nil)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/hcloud/apis/transcoder/infrastructure.go
+++ b/pkg/hcloud/apis/transcoder/infrastructure.go
@@ -29,11 +29,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// MissingProviderConfig is raised when the requested ProviderConfig does not exist
+type MissingProviderConfig struct{}
+
+func (m *MissingProviderConfig) Error() string {
+	return "Missing provider config"
+}
+
 func DecodeInfrastructureConfig(infra *runtime.RawExtension) (*apis.InfrastructureConfig, error) {
 	infraConfig := &apis.InfrastructureConfig{}
 
 	if infra == nil || infra.Raw == nil {
-		return nil, errors.New("Missing provider config")
+		return nil, &MissingProviderConfig{}
 	}
 
 	if _, _, err := decoder.Decode(infra.Raw, nil, infraConfig); err != nil {


### PR DESCRIPTION
When buildup of a cluster fails the state of the object can be
in different unfinished states. If some required arguments where missing,
nothing is build up. The cripped shoot can not be delete because the delete method fails.
Accept missing providerConfig as a non build up cluster in delete operations.

Needs to be tested first, but should fix the delete operation of the shoot x2qlh7nq12 in the testbed

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
