### PR TITLE
Use own image and disable ipv6 as default

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -19,9 +19,9 @@ images:
   tag: v1.6.0
   targetVersion: ">= 1.14"
 - name: hcloud-cloud-controller-manager
-  sourceRepository: github.com/hetznercloud/hcloud-cloud-controller-manager
-  repository: hetznercloud/hcloud-cloud-controller-manager
-  tag: v1.10.0
+  sourceRepository: https://github.com/hetznercloud/hcloud-cloud-controller-manager
+  repository: ghcr.io/23technologies/hcloud-cloud-controller-manager
+  tag: latest
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/charts/internal/seed-controlplane/charts/hcloud-cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/hcloud-cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -69,6 +69,10 @@ spec:
           - name: HCLOUD_NETWORK
             value: {{ .Values.podNetworkIDs.workers | quote }}
           {{- end }}
+          {{- if .Values.disableIPv6 }}
+          - name: HCLOUD_LOAD_BALANCERS_DISABLE_IPV6
+            value: "true"
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/internal/seed-controlplane/charts/hcloud-cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/hcloud-cloud-controller-manager/values.yaml
@@ -11,6 +11,7 @@ featureGates: {}
   # RotateKubeletServerCertificate: false
 images:
   hcloud-cloud-controller-manager: image-repository:image-tag
+disableIPv6: true
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
Use own hcloud-cloud-controller-manager image.
This adds the feature to globally enable/disable ipv6. (default is disable ipv6)

Signed-off-by: Fynn Späker <spaeker@23technologies.cloud>

