### PR TITLE
Fix reveal bearer token

### DIFF
--- a/pkg/hcloud/apis/client.go
+++ b/pkg/hcloud/apis/client.go
@@ -19,6 +19,7 @@ package apis
 
 import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
+	"strings"
 )
 
 var singletons = make(map[string]*hcloud.Client)
@@ -28,6 +29,8 @@ var singletons = make(map[string]*hcloud.Client)
 // PARAMETERS
 // token string Token to look up client instance for
 func GetClientForToken(token string) *hcloud.Client {
+	// if one accidentially copies a newline character into the token, remove it!
+	token = strings.Replace(token, "\n", "", -1)
 	client, ok := singletons[token]
 
 	if !ok {

--- a/pkg/hcloud/apis/client.go
+++ b/pkg/hcloud/apis/client.go
@@ -30,7 +30,10 @@ var singletons = make(map[string]*hcloud.Client)
 // token string Token to look up client instance for
 func GetClientForToken(token string) *hcloud.Client {
 	// if one accidentially copies a newline character into the token, remove it!
-	token = strings.Replace(token, "\n", "", -1)
+	if strings.Contains(token, "\n") {
+		token = strings.Replace(token, "\n", "", -1)
+	}
+
 	client, ok := singletons[token]
 
 	if !ok {

--- a/pkg/hcloud/apis/mock/client.go
+++ b/pkg/hcloud/apis/mock/client.go
@@ -1,0 +1,25 @@
+package mock
+
+import (
+	"strings"
+
+	"net/http"
+)
+
+const (
+	token = "dummy-token"
+)
+
+func SetupTestTokenEndpointOnMux(mux *http.ServeMux) {
+	mux.HandleFunc("/testtokenendpoint", func(res http.ResponseWriter, req *http.Request) {
+
+		auth_bearer_token := req.Header["Authorization"][0]
+		auth_bearer_token = strings.Split(auth_bearer_token, " ")[1]
+		if auth_bearer_token == token {
+			res.WriteHeader(http.StatusOK)
+		}	else {
+			res.WriteHeader(http.StatusForbidden)
+		}
+
+	})
+}

--- a/pkg/hcloud/apis/test/apis_suite_test.go
+++ b/pkg/hcloud/apis/test/apis_suite_test.go
@@ -1,3 +1,22 @@
+/*
+Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// this defined as a subpackage in order to prevent a cycle import loop.
+// We need to import mock in the test and in mock itself apis is imported.
+// Consequently, we need to define this subpackage
 package test
 
 import (

--- a/pkg/hcloud/apis/test/apis_suite_test.go
+++ b/pkg/hcloud/apis/test/apis_suite_test.go
@@ -1,0 +1,13 @@
+package test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestApis(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Apis Suite")
+}

--- a/pkg/hcloud/apis/test/client_test.go
+++ b/pkg/hcloud/apis/test/client_test.go
@@ -68,5 +68,22 @@ var _ = Describe("Api", func() {
 
 		})
 
+		It("should return StatusForbidden", func() {
+
+			hcloudClient := hcloud.NewClient(
+				hcloud.WithEndpoint(mockTestEnv.Server.URL),
+				hcloud.WithHTTPClient(mockTestEnv.Server.Client()),
+				hcloud.WithToken("bogo-token"),
+			)
+
+			apis.SetClientForToken("bogo-token", hcloudClient)
+			client = apis.GetClientForToken("bogo-token")
+
+			req, _ := client.NewRequest(ctx, "GET", fmt.Sprintf("/testtokenendpoint") , nil)
+			resp, _ := client.Do(req, &req.Body)
+
+			Expect( resp.StatusCode ).To(Equal(http.StatusForbidden))
+
+		})
 	})
 })

--- a/pkg/hcloud/apis/test/client_test.go
+++ b/pkg/hcloud/apis/test/client_test.go
@@ -1,0 +1,72 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/23technologies/gardener-extension-provider-hcloud/pkg/hcloud/apis"
+	"github.com/23technologies/gardener-extension-provider-hcloud/pkg/hcloud/apis/mock"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	client        *hcloud.Client
+	ctx           context.Context
+	mockTestEnv   mock.MockTestEnv
+)
+
+var _ = BeforeSuite(func() {
+	ctx = context.TODO()
+	mockTestEnv = mock.NewMockTestEnv()
+
+	mock.SetupTestTokenEndpointOnMux(mockTestEnv.Mux)
+
+})
+
+var _ = AfterSuite(func() {
+	mockTestEnv.Teardown()
+})
+
+var _ = Describe("Api", func() {
+	Describe("#GetClientForToken", func() {
+		It("should return StatusOK", func() {
+
+			hcloudClient := hcloud.NewClient(
+				hcloud.WithEndpoint(mockTestEnv.Server.URL),
+				hcloud.WithHTTPClient(mockTestEnv.Server.Client()),
+				hcloud.WithToken("dummy-token"),
+			)
+
+			apis.SetClientForToken("dummy-token", hcloudClient)
+			client = apis.GetClientForToken("dummy-token")
+
+			req, _ := client.NewRequest(ctx, "GET", fmt.Sprintf("/testtokenendpoint") , nil)
+			resp, _ := client.Do(req, &req.Body)
+
+			Expect( resp.StatusCode ).To(Equal(http.StatusOK))
+
+		})
+
+		It("should return StatusOK", func() {
+
+			hcloudClient := hcloud.NewClient(
+				hcloud.WithEndpoint(mockTestEnv.Server.URL),
+				hcloud.WithHTTPClient(mockTestEnv.Server.Client()),
+				hcloud.WithToken("dummy-token"),
+			)
+
+			apis.SetClientForToken("dummy-token", hcloudClient)
+			client = apis.GetClientForToken("dummy-token\n")
+
+			req, _ := client.NewRequest(ctx, "GET", fmt.Sprintf("/testtokenendpoint") , nil)
+			resp, _ := client.Do(req, &req.Body)
+
+			Expect( resp.StatusCode ).To(Equal(http.StatusOK))
+
+		})
+
+	})
+})

--- a/pkg/hcloud/apis/test/client_test.go
+++ b/pkg/hcloud/apis/test/client_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package test
 
 import (


### PR DESCRIPTION
Signed-off-by: Jens Schneider <schneider@23technologies.cloud>

**What this PR does / why we need it**:
Replaces newline characters in the bearer token.  This is needed, as the token is printed in clear text, if it contains a newline character at the end, which is a common error.
