### PR TITLE
Add hook-me-hcloud.sh

### DIFF
--- a/hack/hook-me-hcloud.sh
+++ b/hack/hook-me-hcloud.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+QUIC_CLIENT_IMAGE=ghcr.io/mvladev/quic-reverse-http-tunnel/quic-client-tcp:v0.1.2
+QUIC_SERVER_IMAGE=ghcr.io/mvladev/quic-reverse-http-tunnel/quic-server:v0.1.2
+
+QUIC_SECRET_NAME=quic-tunnel-certs
+QUIC_CLIENT_CONTAINER=gardener-quic-client
+
+CERTS_DIR=$(pwd)/tmp/certs
+
+checkPrereqs() {
+  command -v host > /dev/null || echo "please install host command for lookup"
+  command -v docker > /dev/null || echo "please install docker https://www.docker.com"
+}
+
+createOrUpdateWebhookSVC(){
+namespace=${1:-}
+[[ -z $namespace ]] && echo "Please specify extension namespace!" && exit 1
+
+serviceName=${2:-}
+[[ -z $serviceName ]] && echo "Please specify the service name (gardener-extension-provider-{aws,gcp,azure},..etc.)!" && exit 1
+
+local quicServerPort=${3:-}
+[[ -z $quicServerPort ]] && echo "Please specify the quic pod server port!" && exit 1
+
+tmpService=$(mktemp)
+kubectl get svc $serviceName -o yaml > $tmpService
+
+    cat <<EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: $serviceName
+    app.kubernetes.io/instance: $serviceName
+    app.kubernetes.io/name: $serviceName
+  name: $serviceName
+  namespace: $namespace
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: $quicServerPort
+  selector:
+    app: quic-server
+    app.kubernetes.io/instance: $serviceName
+    app.kubernetes.io/name: $serviceName
+  type: ClusterIP
+EOF
+}
+
+
+createQuicNP(){
+namespace=${1:-}
+[[ -z $namespace ]] && echo "Please specify extension namespace!" && exit 1
+
+local quicTunnelPort=${2:-}
+[[ -z $quicTunnelPort ]] && echo "Please specify the quic pod tunnel port!" && exit 1
+
+# deploy a NodePort, when running on hcloud, as hcloud does not support UDP-based load-balancers
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: quic-np
+  name: quic-np
+  namespace: $namespace
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - name: quic-tunnel-port
+    port: $quicTunnelPort
+    protocol: UDP
+    targetPort: $quicTunnelPort
+  selector:
+    app: quic-server
+  type: NodePort 
+EOF
+}
+
+waitForQuicNPToBeReady(){
+    namespace=${1:-}
+    [[ -z $namespace ]] && echo "Please specify extension namespace!" && exit 1
+
+    serviceName=${2:-}
+    [[ -z $serviceName ]] && echo "Please specify the service name (gardener-extension-provider-{aws,gcp,azure},..etc.)!" && exit 1
+
+		# just get the ip-address of the first node found in case of running against hcloud
+		sleep 2
+		echo $(kubectl get node -o go-template="{{ (index (index .items 0).status.addresses 1).address }}")
+}
+
+createServerDeploy(){
+namespace=${1:-}
+[[ -z $namespace ]] && echo "Please specify extension namespace!" && exit 1
+
+serviceName=${2:-}
+[[ -z $serviceName ]] && echo "Please specify the service name (gardener-extension-provider-{aws,gcp,azure},..etc.)!" && exit 1
+
+local quicServerPort=${3:-}
+[[ -z $quicServerPort ]] && echo "Please specify the quic pod server port!" && exit 1
+
+local quicTunnelPort=${4:-}
+[[ -z $quicTunnelPort ]] && echo "Please specify the quic pod tunnel port!" && exit 1
+
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: quic-server
+    app.kubernetes.io/instance: $serviceName
+    app.kubernetes.io/name: $serviceName
+    networking.gardener.cloud/to-dns: allowed
+    networking.gardener.cloud/to-public-networks: allowed
+  name: quic-server
+  namespace: $namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: quic-server
+  template:
+    metadata:
+      labels:
+        app: quic-server
+        app.kubernetes.io/instance: $serviceName
+        app.kubernetes.io/name: $serviceName
+    spec:
+      containers:
+      - args:
+        - --listen-tcp=0.0.0.0:$quicServerPort
+        - --listen-quic=0.0.0.0:$quicTunnelPort
+        - --cert-file=/certs/tls.crt
+        - --cert-key=/certs/tls.key
+        - --client-ca-file=/certs/ca.crt
+        image: "${QUIC_SERVER_IMAGE}"
+        imagePullPolicy: IfNotPresent
+        name: quic-server
+        volumeMounts:
+        - name: quic-tls
+          mountPath: "/certs"
+          readOnly: true
+        resources:
+          limits:
+            cpu: 50m
+            memory: 128Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+      - args:
+        - "sleep"
+        - "8000s"
+        image: alpine
+        imagePullPolicy: IfNotPresent
+        name: debug
+        resources:
+          limits:
+            cpu: 50m
+            memory: 128Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+      volumes:
+      - name: quic-tls
+        secret:
+          secretName: ${QUIC_SECRET_NAME}
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: true
+      restartPolicy: Always
+EOF
+}
+
+waitForQuicDeployToBeReady(){
+    namespace=${1:-}
+    [[ -z $namespace ]] && echo "Please specify extension namespace!" && exit 1
+
+    until test "$(kubectl -n $namespace get deploy quic-server --no-headers | awk '{print $2}')" = "1/1"
+    do
+      sleep 2s
+    done
+}
+
+createCerts() {
+  local dir=${1:-}
+  [[ -z $dir ]] && echo "Please specify certs directory!" && exit 1
+
+  mkdir -p $dir
+
+  local ipOrHostname=${2:-}
+  local template=""
+
+  # This will not validate the quads but it is enough to determine if the value is an ip or a hostname
+  if [[ $ipOrHostname =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    template="IP.1 = ${ipOrHostname}"
+  else
+    template="DNS.3 = ${ipOrHostname}"
+  fi
+(
+  cd $dir
+
+  cat > server.conf << EOF
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost
+DNS.2 = quic-tunnel-server
+${template}
+IP.2 = 127.0.0.1
+EOF
+
+  cat > client.conf << EOF
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+EOF
+
+  # Create a certificate authority
+  openssl genrsa -out ca.key 2048
+  openssl req -x509 -new -nodes -key ca.key -days 100000 -out ca.crt -subj "/CN=quic-tunnel-ca"
+
+  # Create a server certiticate
+  openssl genrsa -out tls.key 2048
+  openssl req -new -key tls.key -out server.csr -subj "/CN=quic-tunnel-server" -config server.conf
+  openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 100000 -extensions v3_req -extfile server.conf
+
+  # Create a client certiticate
+  openssl genrsa -out client.key 2048
+  openssl req -new -key client.key -out client.csr -subj "/CN=quic-tunnel-client" -config client.conf
+  openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 100000 -extensions v3_req -extfile client.conf
+
+  # Clean up after we're done.
+  rm ./*.csr
+  rm ./*.srl
+  rm ./*.conf
+)
+}
+
+loadCerts() {
+  local certsDir=${1:-}
+  local namespace=${2:-}
+  local secret=${3:-}
+  [[ -z $certsDir ]] && echo "Please specify local certs Dir!" && exit 1
+  [[ -z $namespace ]] && echo "Please specify extension namespace!" && exit 1
+  [[ -z $secret ]] && echo "Please specify webhook secret name!" && exit 1
+
+  # if it already exists, we get rid of it
+  kubectl -n $namespace delete secret $secret 2>/dev/null || true
+
+  # now create it anew
+  (
+  cd $certsDir
+  kubectl -n $namespace create secret generic $secret --from-file=ca.crt --from-file=tls.key --from-file=tls.crt
+  )
+}
+
+
+cleanUP() {
+   namespace=${1:-}
+   [[ -z $namespace ]] && echo "Please specify the extension namespace!" && exit 1
+
+   echo "cleaning up local-dev setup.."
+
+   echo "Deleting quic service..."
+   kubectl -n $namespace delete  svc/quic-np
+
+   echo "Deleting the quic deploy..."
+   kubectl -n $namespace delete  deploy/quic-server
+
+   echo "Deleting the quic certs..."
+   kubectl -n $namespace delete  secret/quic-tunnel-certs
+
+   echo "Re-applying old service values..."
+   kubectl apply -f $tmpService
+
+   docker kill $QUIC_CLIENT_CONTAINER
+   exit 0
+}
+
+usage(){
+  echo "==================================================================DISCLAIMER============================================================================"
+  echo "This scripts needs to be run against the KUBECONFIG of a seed cluster, please set your KUBECONFIG accordingly"
+  echo "You also need to set the \`ignoreResources\` variable in your extension chart to \`true\`, generate and apply the corresponding controller-installation"
+  echo "========================================================================================================================================================"
+
+  echo ""
+
+  echo "===================================PRE-REQs========================================="
+  echo "\`host\` commands for DNS"
+  echo "\`docker\` https://www.docker.com"
+  echo "===================================================================================="
+
+  echo ""
+
+  echo "========================================================USAGE======================================================================"
+  echo "> ./hack/hook-me.sh <service e.g., gardener-extension-provider-aws> <extension namespace e.g. extension-provider-aws-fpr6w> <webhookserver port e.g., 8443> [<quic-server port, e.g. 9443>]"
+  echo "> \`make EXTENSION_NAMESPACE=<extension namespace e.g. extension-provider-aws-fpr6w> WEBHOOK_CONFIG_MODE=service start\`"
+  echo "=================================================================================================================================="
+
+  echo ""
+
+  echo "===================================CLEAN UP COMMANDS========================================="
+  echo ">  kubectl -n $namespace delete  svc/quic-np"
+  echo ">  kubectl -n $namespace delete  deploy/quic-server"
+  echo "============================================================================================="
+
+  exit 0
+}
+if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
+
+  if [ "$1" == "-h" ] ; then
+        usage
+  fi
+	
+  serviceName=${1:-}
+  [[ -z $serviceName ]] && echo "Please specify the service name (gardener-extension-provider-{aws,gcp,azure},..etc.)!" && exit 1
+
+  namespace=${2:-}
+  [[ -z $namespace ]] && echo "Please specify the extension namespace!" && exit 1
+
+  webhookServerPort=${3:-}
+  [[ -z $webhookServerPort ]] && echo "Please specify webhook server port" && exit 1
+
+  quicServerPort=${4:-}
+  [[ -z $quicServerPort ]] && echo "quic-server port not specified, using default port of 9443" && quicServerPort=9443
+
+  quicTunnelPort=${5:-}
+  [[ -z $quicTunnelPort ]] && echo "quic-tunnel port not specified, using default port of 9444" && quicTunnelPort=9444
+
+  internalDockerHost=${6:-}
+  [[ -z $internalDockerHost ]] && echo "internalDockerHost not specified, using default host.docker.internal" && internalDockerHost=host.docker.internal
+
+  trap 'cleanUP $namespace' SIGINT SIGTERM
+
+  while true; do
+    read -p "[STEP 0] Have you already set the \`ignoreResources\` chart value to \`true\` for your extension controller-registration?" yn
+    case $yn in
+        [Yy]* )
+            echo "[STEP 1] Checking Pre-reqs!"
+            checkPrereqs
+
+            echo "[STEP 2] Creating Quic NP Service..!"
+            createQuicNP $namespace $quicTunnelPort && sleep 2s
+
+            echo "[STEP 3] Waiting for Quic NP Service to be created..!";
+            output=$(waitForQuicNPToBeReady $namespace $serviceName)
+            nodeportIPOrHostName=$(echo "$output" | tail -n1)
+            echo "[Info] NP IP is $nodeportIPOrHostName"
+
+            echo "[STEP 4] Creating the CA, client and server keys and certs..!";
+            createCerts $CERTS_DIR $nodeportIPOrHostName
+
+            echo "[STEP 5] Loading quic tunnel certs into cluster..!";
+            loadCerts $CERTS_DIR $namespace $QUIC_SECRET_NAME
+
+            echo "[STEP 6] Creating the server Deploy for TLS Termination and Tunneling connection..!";
+            createServerDeploy $namespace $serviceName $quicServerPort $quicTunnelPort
+
+            echo "[STEP 7] Waiting for Quic Deploy to be ready..!";
+            waitForQuicDeployToBeReady $namespace
+
+            echo "[STEP 8] Creating WebhookSVC NP..!"
+            createOrUpdateWebhookSVC $namespace $serviceName $quicServerPort
+
+            echo "[STEP 9] Initializing the quic client";
+            echo "[Info] Quic initialized, you are ready to go ahead and run \"make EXTENSION_NAMESPACE=$namespace WEBHOOK_CONFIG_MODE=service start\""
+            echo "[Info] It will take about 5 seconds for the connection to succeeed!"
+
+						# In the case of running on hcloud, we need to get the nodePort from the created service, as hcloud does not support UDP-based load-balancers
+						quicTunnelPort=$(kubectl get service -A --field-selector metadata.name==quic-np -o go-template="{{ (index (index .items 0).spec.ports 0).nodePort }}")
+						
+            echo "[Step 10] Running quic client"
+            docker run \
+              --name ${QUIC_CLIENT_CONTAINER} \
+              --rm \
+              -v "$CERTS_DIR":/certs \
+              $QUIC_CLIENT_IMAGE \
+              --server="$nodeportIPOrHostName:$quicTunnelPort" \
+              --upstream="$internalDockerHost:$webhookServerPort" \
+              --ca-file=/certs/ca.crt \
+              --cert-file=/certs/client.crt \
+              --cert-key=/certs/client.key \
+              --v=5
+        ;;
+        [Nn]* ) echo "You need to set  \`ignoreResources\` to true and generate the controller installlation first in your extension chart before proceeding!"; exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+fi

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity

**What this PR does / why we need it**:
This PR makes it possible to use a variant of the well-known hook-me.sh with hcloud. Hcloud does not support UDP-based load-balancers. Thus, a workaround based on a nodePort is implemented.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Maybe, you can also have a try whether the new script works for you. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```