### PR TITLE
Don't deploy PSPs when PodSecurityPolicy plugin is disabled

### DIFF
--- a/charts/internal/shoot-system-components/charts/hcloud-csi-node/templates/clusterrole-csi-driver.yaml
+++ b/charts/internal/shoot-system-components/charts/hcloud-csi-node/templates/clusterrole-csi-driver.yaml
@@ -16,7 +16,9 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["volumeattachments"]
   verbs: ["get", "list", "watch", "update", "patch"]
+{{- if not .Values.pspDisabled }}
 - apiGroups: ["policy", "extensions"]
   resourceNames: ["{{ include "csi-driver-node.extensionsGroup" . }}.{{ include "csi-driver-node.name" . }}.csi-driver-node"]
   resources: ["podsecuritypolicies"]
   verbs: ["use"]
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/hcloud-csi-node/templates/podsecuritypolicy.yaml
+++ b/charts/internal/shoot-system-components/charts/hcloud-csi-node/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -25,3 +26,4 @@ spec:
   fsGroup:
     rule: RunAsAny
   readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/hcloud-csi-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/hcloud-csi-node/values.yaml
@@ -3,3 +3,5 @@ images:
   csi-driver-registrar: image-repository:image-tag
   liveness-probe: image-repository:image-tag
 token: base64token
+
+pspDisabled: false

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
 	extensionssecretsmanager "github.com/gardener/gardener/extensions/pkg/util/secret/manager"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/chart"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -424,7 +425,7 @@ func (vp *valuesProvider) getCCMChartValues(
 		"podLabels": map[string]interface{}{
 			v1beta1constants.LabelPodMaintenanceRestart: "true",
 		},
-		"podRegion":  region,
+		"podRegion":        region,
 		"serverSecretName": ccmSecret.Name,
 	}
 
@@ -503,6 +504,7 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(
 			"clusterID":         csiClusterID,
 			"token":             credentials.CSI().Token,
 			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+			"pspDisabled":       gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot),
 		},
 	}
 


### PR DESCRIPTION
adopted from https://github.com/gardener/gardener-extension-provider-vsphere/pull/295/commits/7f88fb96f7fdf15d4b489f8c2a00153ce5db242c

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
