### PR TITLE
Add shoot creation timeout to end-to-end test

### DIFF
--- a/hack/ci/03-test-shoot.sh
+++ b/hack/ci/03-test-shoot.sh
@@ -9,10 +9,21 @@ kind get kubeconfig -n gardener-extensions > gardener-kind.yaml
 export KUBECONFIG=gardener-kind.yaml
 yq '.metadata.name=env(TEST_SHOOT_NAME) | .spec.kubernetes.version=env(TEST_SHOOT_VERSION)' hack/ci/misc/test-shoot.yaml | kubectl apply -f -
 
+MAX_TRIES=300
+TRY=0
+WAIT=5
+
 echo "Waiting for shoot creation..."
 while [ ! "$(kubectl get shoot -n garden-project-1 "$TEST_SHOOT_NAME" -o jsonpath="{.status.lastOperation.state}")" == "Succeeded" ]; do
+  (( TRY+=1 ))
+
+  if [[ $TRY -gt $MAX_TRIES ]]; then
+      echo "Shoot creation timed out after $((WAIT * MAX_TRIES)) seconds"
+      exit 1;
+  fi
+
   PERCENTAGE=$(kubectl get shoot -n garden-project-1 "$TEST_SHOOT_NAME" -o jsonpath="{.status.lastOperation.progress}")
   echo "Creating shoot: $PERCENTAGE%"
-  sleep 5
+  sleep $WAIT
 done
 echo "Shoot creation succeeded"


### PR DESCRIPTION
If the test shoot can't be created, the test never fails but waits indefinitely. The new runnerset based runners are terminated after 6 hours and teardown doesn't take place. This PR makes the test shoot creation fail after 25 minutes.