### PR TITLE
Fix potential nil pointer deref on network deletion

### DIFF
--- a/pkg/controller/infrastructure/ensurer/networks.go
+++ b/pkg/controller/infrastructure/ensurer/networks.go
@@ -111,7 +111,7 @@ func EnsureNetworks(ctx context.Context, client *hcloud.Client, namespace, zone 
 // namespace string                               Shoot namespace
 // networks  *apis.InfrastructureConfigNetworkIDs Network IDs struct
 func EnsureNetworksDeleted(ctx context.Context, client *hcloud.Client, namespace string, networks *apis.InfrastructureConfigNetworkIDs) error {
-	if "" != networks.Workers {
+	if networks != nil && "" != networks.Workers {
 		name := fmt.Sprintf("%s-workers", namespace)
 
 		network, _, err := client.Network.GetByName(ctx, name)


### PR DESCRIPTION
This is to fix a nil pointer deref panic that occurred when network deletion is ensured but the infrastructure manifest's status is missing `.providerStatus.networkIDs`.
