### PR TITLE
Improve go dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,6 +45,19 @@
     "packageRules": [
         {
             "matchManagers": ["gomod"],
+            "groupName": "k8s",
+            "matchPackageNames": [
+                "^k8s[.]io/api$",
+                "^k8s[.]io/apiextensions-apiserver$",
+                "^k8s[.]io/apimachinery$",
+                "^k8s[.]io/client-go$",
+                "^k8s[.]io/code-generator$",
+                "^k8s[.]io/component-base$",
+                "^k8s[.]io/kubelet$"
+            ]
+        },
+        {
+            "matchManagers": ["gomod"],
             "automerge": true
         }
     ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
     ],
     "automerge": false,
     "dependencyDashboard": true,
-    "platformAutomerge": false,
+    "platformAutomerge": true,
     "prHourlyLimit": 0,
     "prConcurrentLimit": 0,
     "lockFileMaintenance": {
@@ -40,6 +40,12 @@
             "matchStrings": [
                 "tag: (?<currentValue>.+?) # renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?\\n"
             ]
+        }
+    ],
+    "packageRules": [
+        {
+            "matchManagers": ["gomod"],
+            "automerge": true
         }
     ]
 }


### PR DESCRIPTION
Since there are suitable tests for go mod updates we should use those.
This automerges green go.mod updates and groups those k8s.io modules that have aligned versions to reduce the number of open PRs.